### PR TITLE
chore: add .env.example template for frontend environment variables

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,15 @@
+# Flut Frontend Environment Configuration
+# Copy this file to .env.local and fill in your values.
+
+# Network: "mainnet" or "testnet"
+NEXT_PUBLIC_NETWORK=testnet
+
+# Stacks contract address
+NEXT_PUBLIC_CONTRACT_ADDRESS=ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+
+# Contract names
+NEXT_PUBLIC_CONTRACT_NAME=flut
+NEXT_PUBLIC_NFT_CONTRACT_NAME=flut-nft
+
+# Stacks API endpoint
+NEXT_PUBLIC_STACKS_API=https://api.testnet.hiro.so


### PR DESCRIPTION
Create a template file documenting all required environment variables for the Flut frontend. This serves as documentation and makes setup easier for new developers.